### PR TITLE
Enhanced filters and updated schedule

### DIFF
--- a/data/processed/bha_2026_all_courses_class1-4.csv
+++ b/data/processed/bha_2026_all_courses_class1-4.csv
@@ -1,0 +1,1459 @@
+Date,Weekday,Course,Time,CourseGroup,Region,Code,Surface,Type
+2026-01-01,Thursday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,National/BHA
+2026-01-01,Thursday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA
+2026-01-01,Thursday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,National/BHA
+2026-01-01,Thursday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-01,Thursday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-01,Thursday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-01,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-01-02,Friday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-02,Friday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-02,Friday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,National/BHA
+2026-01-02,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-03,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-03,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-03,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-03,Saturday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-03,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-04,Sunday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-01-04,Sunday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-05,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,National/BHA
+2026-01-05,Monday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-01-05,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-06,Tuesday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-06,Tuesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-06,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-07,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-07,Wednesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-07,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-01-08,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,National/BHA
+2026-01-08,Thursday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-08,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-01-09,Friday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,National/BHA
+2026-01-09,Friday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-09,Friday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-09,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-10,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-10,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-10,Saturday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-10,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-10,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-01-11,Sunday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-11,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-12,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-12,Monday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-12,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-13,Tuesday,Ayr,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-01-13,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA
+2026-01-13,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-14,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-14,Wednesday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-01-14,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-01-15,Thursday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-15,Thursday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-15,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-15,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-01-16,Friday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-16,Friday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-16,Friday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-01-16,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-17,Saturday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-01-17,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-17,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-17,Saturday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-01-17,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-18,Sunday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-01-18,Sunday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-19,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-19,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-19,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-20,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA
+2026-01-20,Tuesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-20,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-21,Wednesday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-21,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-21,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-01-22,Thursday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-22,Thursday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-22,Thursday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-22,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-01-23,Friday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,National/BHA
+2026-01-23,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-23,Friday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-23,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-24,Saturday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-24,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-24,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-24,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-24,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-01-25,Sunday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-25,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-26,Monday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-26,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-01-26,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-27,Tuesday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-27,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-27,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-28,Wednesday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-28,Wednesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-01-28,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-01-29,Thursday,Ayr,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-01-29,Thursday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-29,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-29,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-01-30,Friday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-01-30,Friday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-30,Friday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-30,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-01-31,Saturday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-01-31,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-01-31,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-01-31,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-01-31,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-02-01,Sunday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-01,Sunday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-02,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-02,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-02,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-03,Tuesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-03,Tuesday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-03,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-04,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-04,Wednesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-04,Wednesday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA
+2026-02-04,Wednesday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-02-05,Thursday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-05,Thursday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-05,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-05,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-06,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-06,Friday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-06,Friday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-02-06,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-07,Saturday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-07,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-07,Saturday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-07,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-07,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-08,Sunday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-08,Sunday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,National/BHA
+2026-02-09,Monday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-09,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-09,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-10,Tuesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-10,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-10,Tuesday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-10,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-11,Wednesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-11,Wednesday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-11,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-11,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-02-12,Thursday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-12,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-12,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-12,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-02-13,Friday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-13,Friday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-13,Friday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,National/BHA
+2026-02-13,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-14,Saturday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-14,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-14,Saturday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-14,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-14,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-02-15,Sunday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-15,Sunday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-02-16,Monday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-16,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-16,Monday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-02-17,Tuesday,Newbury,Afternoon,Independent,South,Jump,Turf,National/BHA
+2026-02-17,Tuesday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-17,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-18,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-18,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-18,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-02-19,Thursday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-19,Thursday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-19,Thursday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-19,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-02-20,Friday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,National/BHA
+2026-02-20,Friday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-20,Friday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-20,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-21,Saturday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-21,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-21,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-21,Saturday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-21,Saturday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-02-22,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-22,Sunday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-23,Monday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-23,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-23,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-24,Tuesday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-24,Tuesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-24,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA
+2026-02-24,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-02-25,Wednesday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-02-25,Wednesday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-25,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-25,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-02-26,Thursday,Wetherby,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-02-26,Thursday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-02-26,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-26,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-02-27,Friday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-27,Friday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-27,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-27,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-02-28,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-02-28,Saturday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-02-28,Saturday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-02-28,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-02-28,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-01,Sunday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-01,Sunday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-02,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-02,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-02,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-03,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-03,Tuesday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-03,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-04,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-04,Wednesday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-04,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-03-05,Thursday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-05,Thursday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-05,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-05,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-03-06,Friday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-06,Friday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-06,Friday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-06,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-03-07,Saturday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-07,Saturday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-07,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-07,Saturday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-07,Saturday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-03-08,Sunday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-08,Sunday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-09,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-09,Monday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-09,Monday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-09,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-10,Tuesday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-10,Tuesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-10,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-10,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-11,Wednesday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-11,Wednesday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-11,Wednesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-11,Wednesday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-03-12,Thursday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-12,Thursday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-12,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-03-12,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-03-13,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-13,Friday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-13,Friday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-13,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-13,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-14,Saturday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-14,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-14,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-14,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-14,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-15,Sunday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-15,Sunday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-16,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,National/BHA
+2026-03-16,Monday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-16,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-17,Tuesday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-17,Tuesday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-17,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-18,Wednesday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,National/BHA
+2026-03-18,Wednesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-18,Wednesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-19,Thursday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-19,Thursday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-19,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-03-20,Friday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,National/BHA
+2026-03-20,Friday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-20,Friday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-20,Friday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-03-21,Saturday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-21,Saturday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-21,Saturday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-21,Saturday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-21,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-03-22,Sunday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-22,Sunday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-23,Monday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-23,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-23,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-24,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-24,Tuesday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-24,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-25,Wednesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-25,Wednesday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-25,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-25,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-03-26,Thursday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-26,Thursday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-26,Thursday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-26,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-03-27,Friday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-03-27,Friday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-27,Friday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-03-27,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-03-28,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-03-28,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-03-28,Saturday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-28,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-28,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-03-29,Sunday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-03-29,Sunday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-03-30,Monday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-03-30,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA
+2026-03-30,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-03-31,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-03-31,Tuesday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,National/BHA
+2026-03-31,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-01,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-01,Wednesday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-01,Wednesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-01,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-04-02,Thursday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,National/BHA
+2026-04-02,Thursday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-02,Thursday,Kelso,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-04-02,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-04-03,Friday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA
+2026-04-03,Friday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,National/BHA
+2026-04-03,Friday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,National/BHA
+2026-04-04,Saturday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,National/BHA
+2026-04-04,Saturday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-04,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-04,Saturday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-04,Saturday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-04,Saturday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-05,Sunday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-05,Sunday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-05,Sunday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-05,Sunday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-06,Monday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-06,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-04-06,Monday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-06,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-06,Monday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-07,Tuesday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-07,Tuesday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-07,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-04-08,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-08,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-08,Wednesday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-08,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-04-09,Thursday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-09,Thursday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-09,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-09,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-04-10,Friday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-10,Friday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-10,Friday,Thirsk,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-04-10,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-04-11,Saturday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-11,Saturday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-11,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-04-11,Saturday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-11,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-12,Sunday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,National/BHA
+2026-04-12,Sunday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-12,Sunday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-13,Monday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-13,Monday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-13,Monday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-13,Monday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-04-14,Tuesday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-14,Tuesday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-14,Tuesday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-14,Tuesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-04-15,Wednesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-15,Wednesday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-15,Wednesday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-15,Wednesday,Southwell,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-16,Thursday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-16,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-16,Thursday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-16,Thursday,Hereford,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,National/BHA
+2026-04-17,Friday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-17,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-04-17,Friday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-17,Friday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-17,Friday,Exeter,Evening,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-18,Saturday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-18,Saturday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-18,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-04-18,Saturday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-18,Saturday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-18,Saturday,Nottingham,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-19,Sunday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-19,Sunday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-20,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-04-20,Monday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-20,Monday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-20,Monday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-04-21,Tuesday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-21,Tuesday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-21,Tuesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-21,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-21,Tuesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-22,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-22,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-22,Wednesday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-22,Wednesday,Taunton,Evening,Independent,South,Jump,Turf,Racecourse/Normal
+2026-04-23,Thursday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-23,Thursday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-23,Thursday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-04-23,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-04-24,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-04-24,Friday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-04-24,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-24,Friday,Fontwell Park,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-24,Friday,Chepstow,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-25,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-04-25,Saturday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-25,Saturday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-25,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-04-25,Saturday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-04-25,Saturday,Southwell,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-26,Sunday,Ayr,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-04-26,Sunday,Wetherby,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-26,Sunday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-27,Monday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-04-27,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-04-27,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-28,Tuesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-28,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-28,Tuesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,National/BHA
+2026-04-29,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-04-29,Wednesday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-29,Wednesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-04-29,Wednesday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-04-30,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-04-30,Thursday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-04-30,Thursday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-04-30,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-04-30,Thursday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-01,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-01,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-01,Friday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-01,Friday,Cheltenham,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-01,Friday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-05-02,Saturday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-02,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-02,Saturday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-02,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-02,Saturday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-02,Saturday,Hexham,Evening,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-03,Sunday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-03,Sunday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-03,Sunday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-04,Monday,Beverley,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-05-04,Monday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-05-04,Monday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-04,Monday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-04,Monday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-04,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-05,Tuesday,Ayr,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-05-05,Tuesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-05-05,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-05-05,Tuesday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-06,Wednesday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-06,Wednesday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-06,Wednesday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-05-06,Wednesday,Fontwell Park,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-05-06,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-07,Thursday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-07,Thursday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-07,Thursday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-07,Thursday,Redcar,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-07,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-05-08,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-08,Friday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-08,Friday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-08,Friday,Ripon,Evening,Independent,North,Flat,Turf,National/BHA
+2026-05-08,Friday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-05-09,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-09,Saturday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-09,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-09,Saturday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-09,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Both,Turf,Racecourse/Normal
+2026-05-09,Saturday,Warwick,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-09,Saturday,Leicester,Evening,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-10,Sunday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-10,Sunday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-05-11,Monday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-11,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-11,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-11,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-05-12,Tuesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-12,Tuesday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-12,Tuesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-12,Tuesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-13,Wednesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-13,Wednesday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-13,Wednesday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-13,Wednesday,Newton Abbot,Evening,Independent,South,Jump,Turf,Racecourse/Normal
+2026-05-13,Wednesday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-14,Thursday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-14,Thursday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-14,Thursday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-14,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,National/BHA
+2026-05-14,Thursday,Fontwell Park,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-05-15,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-15,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-15,Friday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-15,Friday,Aintree,Evening,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-05-15,Friday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-16,Saturday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-16,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-16,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-16,Saturday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-16,Saturday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-16,Saturday,Uttoxeter,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-17,Sunday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-05-17,Sunday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-17,Sunday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-18,Monday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-18,Monday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-18,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-18,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-18,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-05-19,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-05-19,Tuesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-19,Tuesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-19,Tuesday,Hexham,Evening,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-19,Tuesday,Huntingdon,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-20,Wednesday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-20,Wednesday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-20,Wednesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-05-20,Wednesday,Yarmouth,Evening,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-20,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-21,Thursday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-21,Thursday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-21,Thursday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-21,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-05-21,Thursday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-05-22,Friday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-22,Friday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-22,Friday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-22,Friday,Pontefract,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-22,Friday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-23,Saturday,Cartmel,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-05-23,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-23,Saturday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-23,Saturday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-23,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-23,Saturday,Salisbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-05-23,Saturday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-24,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-05-24,Sunday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-24,Sunday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-25,Monday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-25,Monday,Cartmel,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-25,Monday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-25,Monday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-25,Monday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-26,Tuesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-26,Tuesday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-26,Tuesday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-26,Tuesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-27,Wednesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-27,Wednesday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-27,Wednesday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-05-27,Wednesday,Cartmel,Evening,Independent,North,Jump,Turf,Racecourse/Normal
+2026-05-27,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-05-28,Thursday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-28,Thursday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-28,Thursday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-28,Thursday,Sandown Park,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-28,Thursday,Market Rasen,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,National/BHA
+2026-05-29,Friday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-29,Friday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-29,Friday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-29,Friday,Stratford-On-Avon,Evening,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-29,Friday,Haydock Park,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-05-30,Saturday,Stratford-On-Avon,Evening,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-31,Sunday,Thirsk,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-05-31,Sunday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-05-31,Sunday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-01,Monday,Newbury,Afternoon,Independent,South,Flat,Turf,National/BHA
+2026-06-01,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-01,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-01,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-06-02,Tuesday,Pontefract,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-06-02,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-02,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-06-02,Tuesday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-06-03,Wednesday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-06-03,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-03,Wednesday,Warwick,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-03,Wednesday,Ripon,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-04,Thursday,Wetherby,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-04,Thursday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-04,Thursday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-04,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-06-04,Thursday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-05,Friday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,National/BHA
+2026-06-05,Friday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-05,Friday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-05,Friday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-05,Friday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-05,Friday,Goodwood,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-06,Saturday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-06,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-06,Saturday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-06,Saturday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-06-06,Saturday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-06,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-06,Saturday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-07,Sunday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-06-07,Sunday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-08,Monday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-08,Monday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-08,Monday,Pontefract,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-08,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-09,Tuesday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-09,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-09,Tuesday,Carlisle,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-09,Tuesday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-10,Wednesday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-06-10,Wednesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-10,Wednesday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-10,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-06-11,Thursday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-11,Thursday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-11,Thursday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-11,Thursday,Catterick Bridge,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-11,Thursday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-12,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-12,Friday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-12,Friday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-12,Friday,Market Rasen,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-12,Friday,Goodwood,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-12,Friday,Newton Abbot,Evening,Independent,South,Jump,Turf,Racecourse/Normal
+2026-06-13,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,National/BHA
+2026-06-13,Saturday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-13,Saturday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-06-13,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-13,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-13,Saturday,Uttoxeter,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-13,Saturday,Leicester,Evening,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-14,Sunday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-14,Sunday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-15,Monday,Wetherby,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-06-15,Monday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-15,Monday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-15,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-16,Tuesday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-16,Tuesday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-16,Tuesday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-16,Tuesday,Beverley,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-16,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-06-17,Wednesday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-17,Wednesday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-17,Wednesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-17,Wednesday,Ripon,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-17,Wednesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-06-18,Thursday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-18,Thursday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,Racecourse/Normal
+2026-06-18,Thursday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-18,Thursday,Southwell,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-06-18,Thursday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-19,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-19,Friday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-19,Friday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-19,Friday,Ayr,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-19,Friday,Goodwood,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-19,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Haydock Park,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-20,Saturday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-21,Sunday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-06-21,Sunday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-21,Sunday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-22,Monday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-06-22,Monday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-22,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-22,Monday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-06-23,Tuesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-23,Tuesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-23,Tuesday,Newton Abbot,Evening,Independent,South,Jump,Turf,Racecourse/Normal
+2026-06-23,Tuesday,Newbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-24,Wednesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-24,Wednesday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-06-24,Wednesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-24,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-06-24,Wednesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-25,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-06-25,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-25,Thursday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-25,Thursday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-25,Thursday,Leicester,Evening,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-26,Friday,Cartmel,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-06-26,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-26,Friday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-26,Friday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-06-26,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-26,Friday,Bangor-On-Dee,Evening,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-27,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-06-27,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-06-27,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-27,Saturday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-27,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-27,Saturday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-28,Sunday,Cartmel,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-06-28,Sunday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-28,Sunday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-06-29,Monday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-06-29,Monday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-06-29,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-30,Tuesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-06-30,Tuesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-06-30,Tuesday,Stratford-On-Avon,Evening,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-06-30,Tuesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-01,Wednesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-01,Wednesday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-01,Wednesday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-01,Wednesday,Epsom Downs,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-02,Thursday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-02,Thursday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-07-02,Thursday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-02,Thursday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-07-02,Thursday,Newbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-03,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-03,Friday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-07-03,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-03,Friday,Beverley,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-03,Friday,Haydock Park,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Carlisle,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-04,Saturday,Nottingham,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-05,Sunday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,Racecourse/Normal
+2026-07-05,Sunday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-05,Sunday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-06,Monday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-06,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-07-06,Monday,Ripon,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-06,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-07,Tuesday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-07,Tuesday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-07,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-07,Tuesday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-08,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-08,Wednesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-08,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-07-08,Wednesday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-09,Thursday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-09,Thursday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-09,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-09,Thursday,Epsom Downs,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-09,Thursday,Newbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-10,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-10,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-10,Friday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-10,Friday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-10,Friday,Chester,Evening,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-11,Saturday,Salisbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-12,Sunday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-07-12,Sunday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-13,Monday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-07-13,Monday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-13,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-13,Monday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-07-14,Tuesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-14,Tuesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-14,Tuesday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-14,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-15,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-15,Wednesday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-15,Wednesday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-15,Wednesday,Yarmouth,Evening,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-15,Wednesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-16,Thursday,Thirsk,Afternoon,Independent,North,Flat,Turf,National/BHA
+2026-07-16,Thursday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-16,Thursday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-16,Thursday,Epsom Downs,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-16,Thursday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-17,Friday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-17,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-17,Friday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-17,Friday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-17,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-17,Friday,Pontefract,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-18,Saturday,Cartmel,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-07-18,Saturday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-18,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-18,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-18,Saturday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-18,Saturday,Doncaster,Evening,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-18,Saturday,Haydock Park,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-19,Sunday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-07-19,Sunday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-19,Sunday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-20,Monday,Cartmel,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-07-20,Monday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-20,Monday,Beverley,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-20,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-21,Tuesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-21,Tuesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-21,Tuesday,Salisbury,Evening,Independent,South,Flat,Turf,National/BHA
+2026-07-21,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-22,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-22,Wednesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-22,Wednesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-22,Wednesday,Leicester,Evening,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-23,Thursday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-23,Thursday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-23,Thursday,Yarmouth,Evening,Arena Racing Corporation Limited,Midlands,Flat,Turf,National/BHA
+2026-07-23,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-07-23,Thursday,Newbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-24,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-24,Friday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-24,Friday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-24,Friday,Sandown Park,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-24,Friday,York,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-24,Friday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-25,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-25,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-07-25,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-25,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-25,Saturday,Salisbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-25,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-26,Sunday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-26,Sunday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-07-27,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-27,Monday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-27,Monday,Ripon,Evening,Independent,North,Flat,Turf,National/BHA
+2026-07-27,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-28,Tuesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-28,Tuesday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-28,Tuesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-28,Tuesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-29,Wednesday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-29,Wednesday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-07-29,Wednesday,Leicester,Evening,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-29,Wednesday,Sandown Park,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-30,Thursday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-30,Thursday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-07-30,Thursday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA
+2026-07-30,Thursday,Epsom Downs,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-31,Friday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-07-31,Friday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-07-31,Friday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-07-31,Friday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-07-31,Friday,Musselburgh,Evening,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-07-31,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-01,Saturday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-02,Sunday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,National/BHA
+2026-08-02,Sunday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-02,Sunday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-03,Monday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,National/BHA
+2026-08-03,Monday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-03,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-04,Tuesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-04,Tuesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-04,Tuesday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-05,Wednesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-05,Wednesday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-05,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-05,Wednesday,Yarmouth,Evening,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-06,Thursday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-06,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-06,Thursday,Chepstow,Evening,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-08-06,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-08-06,Thursday,Sandown Park,Evening,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-07,Friday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-07,Friday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-07,Friday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-07,Friday,Haydock Park,Evening,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-07,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-08,Saturday,Ayr,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-09,Sunday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-09,Sunday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-10,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-10,Monday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-10,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-11,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-11,Tuesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,National/BHA
+2026-08-11,Tuesday,Nottingham,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-11,Tuesday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-12,Wednesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-12,Wednesday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-12,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-12,Wednesday,Ffos Las,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-13,Thursday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-13,Thursday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-13,Thursday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,National/BHA
+2026-08-13,Thursday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-08-14,Friday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-14,Friday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-14,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-14,Friday,Newmarket,Evening,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-14,Friday,Thirsk,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Perth,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-08-15,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Bath,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-15,Saturday,Market Rasen,Evening,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-08-16,Sunday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-16,Sunday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-08-17,Monday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-17,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-17,Monday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-08-17,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-18,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,National/BHA
+2026-08-18,Tuesday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-18,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-08-19,Wednesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-19,Wednesday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-19,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-19,Wednesday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-08-20,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-20,Thursday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-20,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-20,Thursday,Newcastle,Evening,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA
+2026-08-20,Thursday,Stratford-On-Avon,Evening,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-08-21,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-21,Friday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-21,Friday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-21,Friday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-21,Friday,Salisbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-22,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-22,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-22,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-22,Saturday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-08-22,Saturday,Redcar,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-22,Saturday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-23,Sunday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-23,Sunday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-08-24,Monday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-24,Monday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-24,Monday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-25,Tuesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,National/BHA
+2026-08-25,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-25,Tuesday,Stratford-On-Avon,Evening,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-08-26,Wednesday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-26,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-26,Wednesday,Newbury,Evening,Independent,South,Flat,Turf,National/BHA
+2026-08-26,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-08-27,Thursday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-08-27,Thursday,Chelmsford City,Afternoon,Independent,South,Flat,AWT,Racecourse/Normal
+2026-08-27,Thursday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-27,Thursday,Southwell,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA
+2026-08-27,Thursday,Newton Abbot,Evening,Independent,South,Jump,Turf,Racecourse/Normal
+2026-08-28,Friday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-28,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-28,Friday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-28,Friday,Goodwood,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-28,Friday,Fontwell Park,Evening,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-08-28,Friday,Sedgefield,Evening,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-08-29,Saturday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-29,Saturday,Cartmel,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-08-29,Saturday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-29,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-29,Saturday,Windsor,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-29,Saturday,Chelmsford City,Evening,Independent,South,Flat,AWT,Racecourse/Normal
+2026-08-30,Sunday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-30,Sunday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-08-30,Sunday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-08-31,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-08-31,Monday,Cartmel,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-08-31,Monday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-08-31,Monday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-08-31,Monday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-01,Tuesday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-01,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-01,Tuesday,Brighton,Evening,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-01,Tuesday,Wolverhampton,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-09-02,Wednesday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-02,Wednesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-09-02,Wednesday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-02,Wednesday,Hamilton Park,Evening,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-03,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-09-03,Thursday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-03,Thursday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-03,Thursday,Southwell,Evening,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-09-03,Thursday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-04,Friday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-04,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-04,Friday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-04,Friday,Worcester,Evening,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-04,Friday,Kempton Park,Evening,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-05,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-05,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-05,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-05,Saturday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-05,Saturday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-05,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-09-06,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-09-06,Sunday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-07,Monday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-07,Monday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-09-07,Monday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-09-07,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-08,Tuesday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-08,Tuesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-08,Tuesday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-08,Tuesday,Bangor-On-Dee,Evening,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-09,Wednesday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-09,Wednesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-09,Wednesday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-09,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-09-10,Thursday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,National/BHA
+2026-09-10,Thursday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-10,Thursday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-10,Thursday,Lingfield Park,Evening,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-11,Friday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-11,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-11,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-11,Friday,Salisbury,Evening,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-12,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-09-12,Saturday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-12,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-12,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-12,Saturday,Musselburgh,Evening,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-13,Sunday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-13,Sunday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-14,Monday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-09-14,Monday,Thirsk,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-14,Monday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-14,Monday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-09-15,Tuesday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-15,Tuesday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-15,Tuesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-15,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-16,Wednesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-16,Wednesday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-16,Wednesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-16,Wednesday,Kelso,Evening,Independent,North,Jump,Turf,Racecourse/Normal
+2026-09-17,Thursday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-17,Thursday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-17,Thursday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-17,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA
+2026-09-18,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-18,Friday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-09-18,Friday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-18,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-19,Saturday,Chester,Afternoon,Chester Race Company Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-19,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-19,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-19,Saturday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-19,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-09-20,Sunday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-20,Sunday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-09-21,Monday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-21,Monday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-21,Monday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-21,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-22,Tuesday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-09-22,Tuesday,Beverley,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-22,Tuesday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-22,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-23,Wednesday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-09-23,Wednesday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-09-23,Wednesday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-23,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-09-24,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-24,Thursday,Perth,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-09-24,Thursday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-24,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-09-25,Friday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-25,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-25,Friday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-25,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-09-26,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-26,Saturday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-26,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-09-26,Saturday,Ripon,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-26,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-27,Sunday,Epsom Downs,Afternoon,Jockey Club Racecourses Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-27,Sunday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-28,Monday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-28,Monday,Hamilton Park,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-28,Monday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-09-28,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-29,Tuesday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-09-29,Tuesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-09-29,Tuesday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-29,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-09-30,Wednesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-09-30,Wednesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-09-30,Wednesday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-09-30,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-01,Thursday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-01,Thursday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-01,Thursday,Salisbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-01,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-10-02,Friday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-02,Friday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-02,Friday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-02,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-10-03,Saturday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-03,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-03,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-03,Saturday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-03,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-04,Sunday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-04,Sunday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-05,Monday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-05,Monday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-05,Monday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-05,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-05,Monday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-06,Tuesday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-10-06,Tuesday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-06,Tuesday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-06,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-07,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-07,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-07,Wednesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-10-07,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-08,Thursday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-08,Thursday,Ayr,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-08,Thursday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-10-08,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-10-09,Friday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-09,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-09,Friday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-09,Friday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-10-10,Saturday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-10,Saturday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-10,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-10,Saturday,York,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-10,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-11,Sunday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-11,Sunday,Goodwood,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-12,Monday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-10-12,Monday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-12,Monday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-12,Monday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-10-12,Monday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-13,Tuesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-13,Tuesday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-13,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,National/BHA
+2026-10-13,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-14,Wednesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-14,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-14,Wednesday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-14,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-15,Thursday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-15,Thursday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-15,Thursday,Brighton,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-10-15,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-10-16,Friday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-16,Friday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Flat,Turf,Racecourse/Normal
+2026-10-16,Friday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-16,Friday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-16,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-10-17,Saturday,Ascot,Afternoon,Independent,South,Flat,Turf,National/BHA
+2026-10-17,Saturday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-17,Saturday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-10-17,Saturday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-17,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-18,Sunday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-18,Sunday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-10-19,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-10-19,Monday,Pontefract,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-19,Monday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-10-19,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-19,Monday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-20,Tuesday,Hexham,Afternoon,Independent,North,Jump,Turf,National/BHA
+2026-10-20,Tuesday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-20,Tuesday,Yarmouth,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-20,Tuesday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-10-21,Wednesday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-21,Wednesday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-21,Wednesday,Worcester,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-21,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-22,Thursday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-22,Thursday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-10-22,Thursday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-22,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-23,Friday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-23,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-10-23,Friday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-23,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-24,Saturday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-24,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-10-24,Saturday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-24,Saturday,Newbury,Afternoon,Independent,South,Flat,Turf,Racecourse/Normal
+2026-10-24,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-25,Sunday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-10-25,Sunday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-26,Monday,Leicester,Afternoon,Independent,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-26,Monday,Redcar,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-26,Monday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-26,Monday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-26,Monday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-27,Tuesday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-27,Tuesday,Catterick Bridge,Afternoon,Independent,North,Flat,Turf,Racecourse/Normal
+2026-10-27,Tuesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-10-27,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-10-28,Wednesday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-28,Wednesday,Newton Abbot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-10-28,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-28,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-10-29,Thursday,Bath,Afternoon,Arena Racing Corporation Limited,South,Flat,Turf,Racecourse/Normal
+2026-10-29,Thursday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-10-29,Thursday,Stratford-On-Avon,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-29,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-10-30,Friday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-30,Friday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-10-30,Friday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-30,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-10-31,Saturday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-10-31,Saturday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-31,Saturday,Newmarket,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-10-31,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-10-31,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-01,Sunday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-01,Sunday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-02,Monday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-11-02,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-02,Monday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-02,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-02,Monday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-11-03,Tuesday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-03,Tuesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-03,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-03,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-04,Wednesday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-04,Wednesday,Musselburgh,Afternoon,Chester Race Company Limited,North,Flat,Turf,Racecourse/Normal
+2026-11-04,Wednesday,Nottingham,Afternoon,Jockey Club Racecourses Limited,Midlands,Flat,Turf,Racecourse/Normal
+2026-11-04,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-11-05,Thursday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-05,Thursday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-05,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-05,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-11-05,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-11-06,Friday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-06,Friday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-06,Friday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-06,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-11-07,Saturday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-07,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Flat,Turf,Racecourse/Normal
+2026-11-07,Saturday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-07,Saturday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-07,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-08,Sunday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-08,Sunday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-09,Monday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-09,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-10,Tuesday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-10,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-11,Wednesday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-11,Wednesday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-11,Wednesday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-12,Thursday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-12,Thursday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-12,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-13,Friday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-13,Friday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-13,Friday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-14,Saturday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-14,Saturday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-14,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-14,Saturday,Windsor,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-15,Sunday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-15,Sunday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-16,Monday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-16,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-16,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-17,Tuesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-17,Tuesday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,National/BHA
+2026-11-17,Tuesday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-18,Wednesday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-18,Wednesday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-18,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-11-19,Thursday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-19,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-11-19,Thursday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-19,Thursday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-11-20,Friday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-20,Friday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-20,Friday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-20,Friday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-21,Saturday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-21,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-21,Saturday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-21,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-11-21,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-11-22,Sunday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-11-22,Sunday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-23,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-23,Monday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-23,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-11-23,Monday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-11-24,Tuesday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,National/BHA
+2026-11-24,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-11-24,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-24,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-25,Wednesday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-11-25,Wednesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-25,Wednesday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-25,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-11-26,Thursday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-26,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-11-26,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-26,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-11-27,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-27,Friday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-27,Friday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-27,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-11-28,Saturday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-28,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-28,Saturday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-28,Saturday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-28,Saturday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-11-29,Sunday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-11-29,Sunday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-11-30,Monday,Ayr,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-11-30,Monday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,Racecourse/Normal
+2026-11-30,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-11-30,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-01,Tuesday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA
+2026-12-01,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-01,Tuesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-01,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-02,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-02,Wednesday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-02,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-02,Wednesday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-12-03,Thursday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-03,Thursday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-03,Thursday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-03,Thursday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-12-03,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-12-04,Friday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-04,Friday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-04,Friday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-04,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-12-05,Saturday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-05,Saturday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-05,Saturday,Sandown Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-05,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-05,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-12-06,Sunday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-06,Sunday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-07,Monday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-07,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-07,Monday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-07,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-12-08,Tuesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-08,Tuesday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-08,Tuesday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-08,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-09,Wednesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-09,Wednesday,Hexham,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-09,Wednesday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-09,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-12-10,Thursday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-10,Thursday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-10,Thursday,Newcastle,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-10,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-12-11,Friday,Bangor-On-Dee,Afternoon,Chester Race Company Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-11,Friday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-11,Friday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-11,Friday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-12-12,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-12,Saturday,Cheltenham,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-12,Saturday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-12,Saturday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-12,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-12-13,Sunday,Carlisle,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-13,Sunday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-14,Monday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-14,Monday,Plumpton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-14,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-15,Tuesday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-15,Tuesday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-15,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-16,Wednesday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-16,Wednesday,Ludlow,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-16,Wednesday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-16,Wednesday,Kempton Park,Floodlit,Jockey Club Racecourses Limited,South,Flat,AWT,National/BHA Floodlit
+2026-12-17,Thursday,Exeter,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-17,Thursday,Ffos Las,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-17,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-17,Thursday,Chelmsford City,Floodlit,Independent,South,Flat,AWT,National/BHA Floodlit
+2026-12-18,Friday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-18,Friday,Southwell,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-18,Friday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-18,Friday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-12-19,Saturday,Ascot,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-19,Saturday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-19,Saturday,Hereford,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-19,Saturday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-19,Saturday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,National/BHA Floodlit
+2026-12-20,Sunday,Fakenham,Afternoon,Independent,Midlands,Jump,Turf,National/BHA
+2026-12-20,Sunday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-21,Monday,Huntingdon,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-21,Monday,Musselburgh,Afternoon,Chester Race Company Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-21,Monday,Taunton,Afternoon,Independent,South,Jump,Turf,National/BHA
+2026-12-21,Monday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-12-22,Tuesday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-22,Tuesday,Sedgefield,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-22,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,National/BHA Floodlit
+2026-12-26,Saturday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-26,Saturday,Aintree,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Fontwell Park,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Market Rasen,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Wincanton,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-26,Saturday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-27,Sunday,Chepstow,Afternoon,Arena Racing Corporation Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-27,Sunday,Kempton Park,Afternoon,Jockey Club Racecourses Limited,South,Jump,Turf,Racecourse/Normal
+2026-12-27,Sunday,Wetherby,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-27,Sunday,Wolverhampton,Afternoon,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-28,Monday,Catterick Bridge,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-28,Monday,Leicester,Afternoon,Independent,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-28,Monday,Newbury,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-28,Monday,Southwell,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-29,Tuesday,Doncaster,Afternoon,Arena Racing Corporation Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-29,Tuesday,Kelso,Afternoon,Independent,North,Jump,Turf,Racecourse/Normal
+2026-12-29,Tuesday,Wolverhampton,Floodlit,Arena Racing Corporation Limited,Midlands,Flat,AWT,Racecourse/Normal
+2026-12-30,Wednesday,Haydock Park,Afternoon,Jockey Club Racecourses Limited,North,Jump,Turf,Racecourse/Normal
+2026-12-30,Wednesday,Taunton,Afternoon,Independent,South,Jump,Turf,Racecourse/Normal
+2026-12-30,Wednesday,Newcastle,Floodlit,Arena Racing Corporation Limited,North,Flat,AWT,Racecourse/Normal
+2026-12-31,Thursday,Lingfield Park,Afternoon,Arena Racing Corporation Limited,South,Flat,AWT,Racecourse/Normal
+2026-12-31,Thursday,Uttoxeter,Afternoon,Arena Racing Corporation Limited,Midlands,Jump,Turf,Racecourse/Normal
+2026-12-31,Thursday,Warwick,Afternoon,Jockey Club Racecourses Limited,Midlands,Jump,Turf,Racecourse/Normal

--- a/scripts/extract_bha_2026_four_courses.py
+++ b/scripts/extract_bha_2026_four_courses.py
@@ -1,39 +1,22 @@
 #!/usr/bin/env python3
-"""Extract 2026 BHA fixture rows for four target courses and save CSV.
+"""Extract 2026 BHA fixture rows (all courses, Class 1-4 only) and save CSV.
 
-Writes: data/processed/bha_2026_ascot_newmarket_doncaster_york.csv
+Writes: data/processed/bha_2026_all_courses_class1-4.csv
 """
 from pathlib import Path
 import sys
 import pandas as pd
 
 INPUT = Path("data/raw/2026_Fixture_List.xlsx")
-OUT = Path("data/processed/bha_2026_ascot_newmarket_doncaster_york.csv")
-TARGETS = ["Ascot", "Newmarket", "Doncaster", "York"]
+OUT = Path("data/processed/bha_2026_all_courses_class1-4.csv")
 
-def find_course_column(df: pd.DataFrame):
-    candidates = [
-        "Course",
-        "Venue",
-        "Track",
-        "Course Name",
-        "Racecourse",
-        "Location",
-        "Racecourse Name",
-    ]
+def find_class_column(df: pd.DataFrame):
+    """Find the column containing race class information"""
+    candidates = ["Class", "Race Class", "RaceClass", "Grade"]
     for c in df.columns:
         for k in candidates:
             if c.strip().lower() == k.strip().lower():
                 return c
-
-    # Fallback: find a column that contains at least one target name
-    for c in df.columns:
-        try:
-            sample = df[c].dropna().astype(str).head(200).str.lower()
-        except Exception:
-            continue
-        if sample.apply(lambda x: any(t.lower() in x for t in TARGETS)).any():
-            return c
     return None
 
 
@@ -47,19 +30,36 @@ def main():
     # Normalize column names
     df.columns = [str(c).strip() for c in df.columns]
 
-    course_col = find_course_column(df)
-    if course_col is None:
-        print("Could not detect a course/track column. Columns:\n", df.columns.tolist())
-        sys.exit(3)
-
-    pattern = r"\b(?:" + "|".join([p.replace("(", "\\(").replace(")", "\\)") for p in TARGETS]) + r")\b"
-    mask = df[course_col].astype(str).str.contains(pattern, case=False, na=False, regex=True)
-    out_df = df[mask].copy()
+    # Find class column
+    class_col = find_class_column(df)
+    
+    if class_col is None:
+        print("Warning: Could not detect a class column. Including all classes.")
+        print("Available columns:", df.columns.tolist())
+        out_df = df.copy()
+    else:
+        # Filter to Class 1-4 only (exclude Class 5, 6, 7)
+        print(f"Found class column: {class_col}")
+        print(f"Original rows: {len(df)}")
+        
+        # Convert to string and extract class number
+        df['class_str'] = df[class_col].astype(str).str.strip()
+        
+        # Filter out Class 5, 6, 7
+        excluded_pattern = r'\b(?:Class\s*[567]|[567])\b'
+        mask = ~df['class_str'].str.contains(excluded_pattern, case=False, na=False, regex=True)
+        out_df = df[mask].copy()
+        
+        # Drop temporary column
+        out_df = out_df.drop('class_str', axis=1)
+        
+        print(f"Filtered rows (Class 1-4 only): {len(out_df)}")
+        print(f"Removed: {len(df) - len(out_df)} Class 5-7 races")
 
     OUT.parent.mkdir(parents=True, exist_ok=True)
     out_df.to_csv(OUT, index=False)
 
-    print(f"Wrote {len(out_df)} rows to {OUT}")
+    print(f"\nWrote {len(out_df)} rows to {OUT}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces significant enhancements to the race prediction application, focusing on improving the filtering and display of race data, especially around profitability scoring and fixture extraction. The main changes include adding new sidebar filters for race tier and score, a new expander for top predictive races, and updating the fixture extraction script to process all courses and restrict to Class 1-4 races.

**User Interface and Filtering Improvements:**

* Added a new Streamlit expander to display the top upcoming "Tier 1 Focus" races (score ≥70), showing key details and formatting for clarity.
* Introduced new sidebar filters for "Race Tier (Profitability)" and "Race Score," allowing users to filter races based on profitability tiers and score ranges. These are now incorporated into the filtering logic and ordering of sidebar controls. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL211-R282) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL330-R431)
* Reordered and renumbered all sidebar filters for clarity, with new filters for tier and score appearing before class, prize, and other filters. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL224-R295) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL237-R308) [[3]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL252-R323) [[4]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL265-R336) [[5]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL279-R350) [[6]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL289-R360)
* Updated the filtering logic to apply the new tier and score filters before class, prize, and other filters, ensuring correct order of application. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL330-R431) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL358-R444)

**Fixture Extraction Script Updates:**

* Modified `scripts/extract_bha_2026_four_courses.py` to extract fixtures for all courses (not just four), and filter to only include Class 1-4 races. The output file and script documentation have been updated accordingly. [[1]](diffhunk://#diff-c372167d3f2abf8c58a7a1a372a515122574af2cacedb113b1c234a7e451bb8aL2-L36) [[2]](diffhunk://#diff-c372167d3f2abf8c58a7a1a372a515122574af2cacedb113b1c234a7e451bb8aL50-R62)
* Improved detection of the class column and filtering logic to exclude Class 5-7 races, with clearer logging and fallback behavior if the class column is missing.

**File Reference Update:**

* Updated the fixture file reference in the main app to point to the new all-courses, Class 1-4 fixture file.