### PR TITLE
Add Back to Top links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ A full-featured web interface for exploring race data, analyzing predictions, an
 
 **Run Predictions:** `python scripts/score_fixture_calendar.py`
 
+[Back to Top](#table-of-contents)
+
 ---
 
 ## Project Components
@@ -169,6 +171,8 @@ A full-featured web interface for exploring race data, analyzing predictions, an
 - Performance backtesting
 - Production deployment automation
 
+[Back to Top](#table-of-contents)
+
 ---
 
 ## Quick Start
@@ -190,6 +194,8 @@ streamlit run predictions.py
 ```
 
 The app will open in your browser at `http://localhost:8501`
+
+[Back to Top](#table-of-contents)
 
 ---
 
@@ -240,6 +246,8 @@ horse-racing-predictions/
     └── utils/                # Helper functions
 ```
 
+[Back to Top](#table-of-contents)
+
 ---
 
 ## API Data Sources
@@ -273,6 +281,8 @@ horse-racing-predictions/
 - Use cached data in tests (see `tests/fixtures/`)
 - Batch API calls where possible
 - Monitor usage with `examples/api_example.py`
+
+[Back to Top](#table-of-contents)
 
 ---
 
@@ -363,6 +373,8 @@ python scripts/phase3_build_horse_model.py
 python scripts/score_fixture_calendar.py
 ```
 
+[Back to Top](#table-of-contents)
+
 ---
 
 ## Development
@@ -426,6 +438,12 @@ Both APIs have 500 calls/month limits:
 
 **Project Status:** Active Development
 
+[Back to Top](#table-of-contents)
+
 **Current Phase:** Phase 3 complete (ML model), Phase 4 in progress (betting strategy)
 
+[Back to Top](#table-of-contents)
+
 **License:** See repository for license information
+
+[Back to Top](#table-of-contents)


### PR DESCRIPTION
This pull request adds navigation improvements to the `README.md` file by including multiple "[Back to Top](#table-of-contents)" links throughout the document. These links make it easier for users to quickly return to the table of contents from different sections, enhancing the overall usability of the documentation.

Documentation navigation enhancements:

* Added "[Back to Top](#table-of-contents)" links after major sections such as Run Predictions, Project Components, Quick Start, Project Structure, API Data Sources, Installation, Development, Project Status, Current Phase, and License to improve accessibility and user experience. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134-R135) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174-R175) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R198-R199) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R249-R250) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R285-R286) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R376-R377) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R441-R449)