### PR TITLE
Fix Use Container Width error

### DIFF
--- a/predictions.py
+++ b/predictions.py
@@ -848,7 +848,7 @@ def main():
             display_df[display_columns],
             hide_index=True,
             height=height,
-            use_container_width=True
+            width='stretch'
         )
     
     with tab7:
@@ -932,7 +932,8 @@ def main():
                 }).round(1)
                 course_stats.columns = ['Total Races', 'Avg Score', 'Max Score', 'Tier 1 Count']
                 course_stats = course_stats.sort_values('Max Score', ascending=False).head(15)
-                st.dataframe(course_stats, height=400, use_container_width=True)
+                height = get_dataframe_height(course_stats)
+                st.dataframe(course_stats, height=height, width='stretch')
                 
                 # Filterable table of all fixtures
                 st.subheader("All Predicted Fixtures")
@@ -982,7 +983,7 @@ def main():
                 
                 st.info(f"Showing {len(display_fixtures):,} of {len(fixtures_scored):,} predicted fixtures")
                 height = get_dataframe_height(display_fixtures, max_height=600)
-                st.dataframe(display_fixtures, hide_index=True, height=height, use_container_width=True)
+                st.dataframe(display_fixtures, hide_index=True, height=height, width='stretch')
                 
             except Exception as e:
                 st.error(f"Error loading predicted fixtures: {e}")
@@ -1042,7 +1043,7 @@ def main():
                             tier1_display['race_score'] = tier1_display['race_score'].round(1)
                         
                         tier1_display.columns = [c.title() for c in tier1_display.columns]
-                        st.dataframe(tier1_display, hide_index=True, use_container_width=True)
+                        st.dataframe(tier1_display, hide_index=True, width='stretch')
                     
                     # Show Tier 2 races
                     tier2_races = watchlist[watchlist['betting_tier'] == 'Tier 2: Value'].copy()
@@ -1063,7 +1064,7 @@ def main():
                         
                         tier2_display.columns = [c.title() for c in tier2_display.columns]
                         with st.expander("Show Tier 2 Races", expanded=False):
-                            st.dataframe(tier2_display, hide_index=True, use_container_width=True)
+                            st.dataframe(tier2_display, hide_index=True, width='stretch')
                     
                     # Betting workflow guidance
                     st.markdown("---")
@@ -1106,7 +1107,7 @@ def main():
                             tier_stats = tier_stats.sort_values('Avg Score', ascending=False)
                             
                             st.write("**Race counts and average scores by betting tier:**")
-                            st.dataframe(tier_stats, use_container_width=True)
+                            st.dataframe(tier_stats, width='stretch')
                             
                             st.caption("Note: Historical tiers use strict criteria. Upcoming predictions use relaxed criteria due to limited data.")
                 
@@ -1156,10 +1157,10 @@ def main():
             else:
                 top_25.columns = ['Time', 'Course', 'Horse', 'Jockey', 'Win %', 'Class', 'Distance', 'OR']
             
-            st.dataframe(top_25, hide_index=True, use_container_width=True)
+            st.dataframe(top_25, hide_index=True, width='stretch')
             
-            if not has_odds:
-                st.info("💡 **Add live odds:** Run `python scripts/fetch_odds.py --date " + today_str + "` to fetch bookmaker odds and enable value bet detection")
+            # if not has_odds:
+                # st.info("💡 **Add live odds:** Run `python scripts/fetch_odds.py --date " + today_str + "` to fetch bookmaker odds and enable value bet detection")
             
             # Show timezone info
             if 'race_time_gmt' in predictions.columns:
@@ -1215,7 +1216,7 @@ def main():
             # Add ranking
             display_df.insert(0, 'Rank', range(1, len(display_df) + 1))
             
-            st.dataframe(display_df, hide_index=True, use_container_width=True)
+            st.dataframe(display_df, hide_index=True, width='stretch')
             
             # Value betting section
             st.markdown("##### 💰 Value Betting Analysis")
@@ -1240,7 +1241,7 @@ def main():
                 display = value_analysis[['horse', 'win_probability_fmt', 'bookmaker_odds_fmt', 'fair_odds_fmt', 'edge_fmt', 'is_value']].copy()
                 display.columns = ['Horse', 'Model Win %', 'Bookmaker Odds', 'Fair Odds', 'Edge', 'Value Bet?']
                 
-                st.dataframe(display, hide_index=True, use_container_width=True)
+                st.dataframe(display, hide_index=True, width='stretch')
                 
                 # Highlight value bets
                 value_bets = value_analysis[value_analysis['is_value']]
@@ -1267,7 +1268,7 @@ def main():
                     st.markdown("*Fair odds based on model probabilities:*")
                     display = top_3[['horse', 'win_probability_pct', 'fair_odds_fmt']].copy()
                     display.columns = ['Horse', 'Model Win %', 'Fair Decimal Odds']
-                    st.dataframe(display, hide_index=True, use_container_width=True)
+                    st.dataframe(display, hide_index=True, width='stretch')
                     
                     st.markdown("**Betting Rule:** Only bet if bookmaker odds > fair odds (with margin for edge)")
                     st.info("💡 Fetch odds with: `python scripts/fetch_odds.py --date " + today_str + "`")
@@ -1289,31 +1290,31 @@ def main():
                     st.metric("Recent Form (Avg Pos)", f"{top_horse['avg_last_3_pos']:.1f}")
                     st.metric("Wins Last 3", int(top_horse['wins_last_3']))
             
-            st.markdown("---")
+            # st.markdown("---")
             
-            # Instructions for fetching odds
-            with st.expander("🔧 How to Add Live Odds"):
-                st.markdown("""
-                **To enable value bet detection, integrate odds data:**
+            # # Instructions for fetching odds
+            # with st.expander("🔧 How to Add Live Odds"):
+            #     st.markdown("""
+            #     **To enable value bet detection, integrate odds data:**
                 
-                1. **Use The Odds API** - https://the-odds-api.com
-                   - Free tier: 500 requests/month
-                   - Covers major bookmakers
+            #     1. **Use The Odds API** - https://the-odds-api.com
+            #        - Free tier: 500 requests/month
+            #        - Covers major bookmakers
                 
-                2. **Or scrape odds from:**
-                   - Oddschecker.com
-                   - Betfair Exchange
-                   - Racing Post
+            #     2. **Or scrape odds from:**
+            #        - Oddschecker.com
+            #        - Betfair Exchange
+            #        - Racing Post
                 
-                3. **Store odds in CSV** alongside predictions
+            #     3. **Store odds in CSV** alongside predictions
                 
-                4. **Calculate value automatically:**
-                   ```python
-                   value = model_prob - (1 / decimal_odds)
-                   if value > 0.05:  # 5% edge minimum
-                       # This is a value bet
-                   ```
-                """)
+            #     4. **Calculate value automatically:**
+            #        ```python
+            #        value = model_prob - (1 / decimal_odds)
+            #        if value > 0.05:  # 5% edge minimum
+            #            # This is a value bet
+            #        ```
+            #     """)
         
         else:
             # No predictions for today
@@ -1352,7 +1353,7 @@ def main():
                     display_df['dist_f'] = display_df['dist_f'].apply(lambda x: f"{x}f")
                     display_df.columns = ['Date', 'Course', 'Class', 'Distance', 'Prize', 'Score']
                     
-                    st.dataframe(display_df, hide_index=True, use_container_width=True)
+                    st.dataframe(display_df, hide_index=True, width='stretch')
                     st.caption("Fetch racecards 24-48h before race date to get predictions")
                 else:
                     st.info("No upcoming races in watchlist")


### PR DESCRIPTION
This pull request updates the way dataframes are displayed in the `predictions.py` Streamlit app. The main change is replacing the deprecated or less flexible `use_container_width=True` parameter with `width='stretch'` for all `st.dataframe` calls, ensuring consistent and responsive table layouts. Additionally, some informational sections and instructions related to fetching odds have been commented out, likely to streamline the user interface.

The most important changes are:

**Dataframe display improvements:**

* All instances of `st.dataframe` now use `width='stretch'` instead of `use_container_width=True`, providing a more consistent and modern way to make tables responsive across the app. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL851-R851) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL935-R936) [[3]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL985-R986) [[4]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1045-R1046) [[5]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1066-R1067) [[6]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1109-R1110) [[7]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1159-R1163) [[8]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1218-R1219) [[9]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1243-R1244) [[10]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1270-R1271) [[11]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1355-R1356)

**User interface and guidance changes:**

* Several informational messages and instructions for fetching bookmaker odds and enabling value bet detection have been commented out, reducing UI clutter and possibly deferring this guidance for future refinement. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1159-R1163) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1292-R1317)