### PR TITLE
Modified predictions to be 25 per day

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,3 +539,5 @@ Quick checklist:
 - Validate on holdout and per-course/going slices (start with sprint tracks).
 
 Expected near-term impact: combined +0.03–0.08 AUC if implemented and tuned (see docs for per-feature estimates).
+
+[Back to Top](#table-of-contents)


### PR DESCRIPTION
This pull request restructures how "Handicap Betting Opportunities" are displayed in the predictions app by moving their summary and explanation to the end of the report, and updates the "Top Predictions" section to show the top 25 predictions per day instead of the top 50 overall. The changes improve the clarity and organization of the output, ensuring that key betting angles and performance summaries are more accessible and relevant to users.

**Key changes:**

### Predictions display and summary improvements

- Changed the "Top Predictions" section to display the top 25 predictions per day, sorted by date and win probability, instead of the top 50 overall. This provides a more balanced view across multiple days. [[1]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1520-R1523) [[2]](diffhunk://#diff-6a46de3f55ec4161b8881692824c01d2cc887f117e3085f20dba96f7e80f13acL1683-R1552)

### Handicap opportunities summary refactor

- Moved the "Handicap Betting Opportunities" summary, explanation, and calculation to the end of the report for better flow and user experience. The summary now analyzes both today's and tomorrow's predictions if available.
- Removed the earlier, inline calculation and display of handicap opportunities from the middle of the report to avoid duplication and improve structure.

### Documentation

- Added a "Back to Top" anchor link at the end of the "Quick checklist" section in `README.md` for easier navigation.