### PR TITLE
Potential fix to server not showing tomorrow's races

### DIFF
--- a/predictions.py
+++ b/predictions.py
@@ -29,11 +29,19 @@ def get_now_local(tz_name: str | None = None) -> datetime:
     """Return a timezone-aware 'now' datetime for the given IANA tz name.
 
     If tz_name is None, the function will consult the `APP_TIMEZONE`
-    environment variable. If ZoneInfo is unavailable or the tz name is
+    environment variable, then Streamlit `secrets` (if present). If ZoneInfo is
     invalid, falls back to the system local timezone.
     """
     if tz_name is None:
+        # Prefer explicit environment variable
         tz_name = os.environ.get('APP_TIMEZONE')
+        # Fall back to Streamlit secrets (useful on Streamlit Cloud where
+        # users may have set APP_TIMEZONE in the Secrets UI)
+        if not tz_name:
+            try:
+                tz_name = st.secrets.get('APP_TIMEZONE') if hasattr(st, 'secrets') else None
+            except Exception:
+                tz_name = None
 
     if tz_name and ZoneInfo is not None:
         try:


### PR DESCRIPTION
This pull request updates the logic for determining the application's timezone in the `get_now_local` function. It now checks the Streamlit `secrets` configuration for the `APP_TIMEZONE` value if the environment variable is not set, improving compatibility with Streamlit Cloud deployments.

Timezone resolution improvements:

* Enhanced the fallback mechanism in `get_now_local` (in `predictions.py`) to check for `APP_TIMEZONE` in Streamlit `secrets` if the environment variable is not set, providing better support for Streamlit Cloud users.